### PR TITLE
Generic ClaimReconciler

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/onsi/gomega v1.27.6
 	github.com/pkg/errors v0.9.1
 	go4.org/netipx v0.0.0-20230303233057-f1b76eb4bb35
+	golang.org/x/exp v0.0.0-20230425010034-47ecfdc1ba53
 	k8s.io/api v0.26.1
 	k8s.io/apimachinery v0.26.1
 	k8s.io/client-go v0.26.1

--- a/go.sum
+++ b/go.sum
@@ -198,6 +198,8 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.3.0 h1:a06MkbcxBrEFc0w0QIZWXrH/9cCX6KJyWbBOIwAn+7A=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
+golang.org/x/exp v0.0.0-20230425010034-47ecfdc1ba53 h1:5llv2sWeaMSnA3w2kS57ouQQ4pudlXrR0dCgw51QK9o=
+golang.org/x/exp v0.0.0-20230425010034-47ecfdc1ba53/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=

--- a/internal/controllers/ipaddressclaim_test.go
+++ b/internal/controllers/ipaddressclaim_test.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+	"github.com/telekom/cluster-api-ipam-provider-in-cluster/pkg/ipamutil"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -137,7 +138,7 @@ var _ = Describe("IPAddressClaimReconciler", func() {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       "test",
 						Namespace:  namespace,
-						Finalizers: []string{ProtectAddressFinalizer},
+						Finalizers: []string{ipamutil.ProtectAddressFinalizer},
 						OwnerReferences: []metav1.OwnerReference{
 							{
 								APIVersion:         "ipam.cluster.x-k8s.io/v1alpha1",
@@ -225,7 +226,7 @@ var _ = Describe("IPAddressClaimReconciler", func() {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       "test",
 						Namespace:  namespace,
-						Finalizers: []string{ProtectAddressFinalizer},
+						Finalizers: []string{ipamutil.ProtectAddressFinalizer},
 						OwnerReferences: []metav1.OwnerReference{
 							{
 								APIVersion:         "ipam.cluster.x-k8s.io/v1alpha1",
@@ -325,7 +326,7 @@ var _ = Describe("IPAddressClaimReconciler", func() {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       "test",
 						Namespace:  namespace,
-						Finalizers: []string{ProtectAddressFinalizer},
+						Finalizers: []string{ipamutil.ProtectAddressFinalizer},
 						OwnerReferences: []metav1.OwnerReference{
 							{
 								APIVersion:         "ipam.cluster.x-k8s.io/v1alpha1",
@@ -425,7 +426,7 @@ var _ = Describe("IPAddressClaimReconciler", func() {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       "test",
 						Namespace:  namespace,
-						Finalizers: []string{ProtectAddressFinalizer},
+						Finalizers: []string{ipamutil.ProtectAddressFinalizer},
 						OwnerReferences: []metav1.OwnerReference{
 							{
 								APIVersion:         "ipam.cluster.x-k8s.io/v1alpha1",
@@ -462,7 +463,7 @@ var _ = Describe("IPAddressClaimReconciler", func() {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       "test-second-namespace",
 						Namespace:  secondNamespace,
-						Finalizers: []string{ProtectAddressFinalizer},
+						Finalizers: []string{ipamutil.ProtectAddressFinalizer},
 						OwnerReferences: []metav1.OwnerReference{
 							{
 								APIVersion:         "ipam.cluster.x-k8s.io/v1alpha1",
@@ -585,7 +586,7 @@ var _ = Describe("IPAddressClaimReconciler", func() {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       "test-1",
 						Namespace:  namespace,
-						Finalizers: []string{ProtectAddressFinalizer},
+						Finalizers: []string{ipamutil.ProtectAddressFinalizer},
 						OwnerReferences: []metav1.OwnerReference{
 							{
 								APIVersion:         "ipam.cluster.x-k8s.io/v1alpha1",
@@ -622,7 +623,7 @@ var _ = Describe("IPAddressClaimReconciler", func() {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       "test-2",
 						Namespace:  namespace,
-						Finalizers: []string{ProtectAddressFinalizer},
+						Finalizers: []string{ipamutil.ProtectAddressFinalizer},
 						OwnerReferences: []metav1.OwnerReference{
 							{
 								APIVersion:         "ipam.cluster.x-k8s.io/v1alpha1",
@@ -755,7 +756,7 @@ var _ = Describe("IPAddressClaimReconciler", func() {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       "test-1",
 						Namespace:  namespace,
-						Finalizers: []string{ProtectAddressFinalizer},
+						Finalizers: []string{ipamutil.ProtectAddressFinalizer},
 						OwnerReferences: []metav1.OwnerReference{
 							{
 								APIVersion:         "ipam.cluster.x-k8s.io/v1alpha1",
@@ -792,7 +793,7 @@ var _ = Describe("IPAddressClaimReconciler", func() {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       "test-2",
 						Namespace:  secondNamespace,
-						Finalizers: []string{ProtectAddressFinalizer},
+						Finalizers: []string{ipamutil.ProtectAddressFinalizer},
 						OwnerReferences: []metav1.OwnerReference{
 							{
 								APIVersion:         "ipam.cluster.x-k8s.io/v1alpha1",
@@ -922,7 +923,7 @@ var _ = Describe("IPAddressClaimReconciler", func() {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       "test-1",
 						Namespace:  namespace,
-						Finalizers: []string{ProtectAddressFinalizer},
+						Finalizers: []string{ipamutil.ProtectAddressFinalizer},
 						OwnerReferences: []metav1.OwnerReference{
 							{
 								APIVersion:         "ipam.cluster.x-k8s.io/v1alpha1",
@@ -959,7 +960,7 @@ var _ = Describe("IPAddressClaimReconciler", func() {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       "test-2",
 						Namespace:  namespace,
-						Finalizers: []string{ProtectAddressFinalizer},
+						Finalizers: []string{ipamutil.ProtectAddressFinalizer},
 						OwnerReferences: []metav1.OwnerReference{
 							{
 								APIVersion:         "ipam.cluster.x-k8s.io/v1alpha1",
@@ -1222,7 +1223,7 @@ var _ = Describe("IPAddressClaimReconciler", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "test",
 					Namespace:  namespace,
-					Finalizers: []string{ProtectAddressFinalizer},
+					Finalizers: []string{ipamutil.ProtectAddressFinalizer},
 					OwnerReferences: []metav1.OwnerReference{
 						{
 							APIVersion:         "ipam.cluster.x-k8s.io/v1alpha1",
@@ -1334,7 +1335,7 @@ var _ = Describe("IPAddressClaimReconciler", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "test",
 					Namespace:  namespace,
-					Finalizers: []string{ProtectAddressFinalizer},
+					Finalizers: []string{ipamutil.ProtectAddressFinalizer},
 					OwnerReferences: []metav1.OwnerReference{
 						{
 							APIVersion: "alpha-dummy",
@@ -1609,7 +1610,7 @@ var _ = Describe("IPAddressClaimReconciler", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "test",
 					Namespace:  namespace,
-					Finalizers: []string{ProtectAddressFinalizer},
+					Finalizers: []string{ipamutil.ProtectAddressFinalizer},
 					OwnerReferences: []metav1.OwnerReference{
 						{
 							APIVersion:         "ipam.cluster.x-k8s.io/v1alpha1",
@@ -1719,7 +1720,7 @@ var _ = Describe("IPAddressClaimReconciler", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "test",
 					Namespace:  namespace,
-					Finalizers: []string{ProtectAddressFinalizer},
+					Finalizers: []string{ipamutil.ProtectAddressFinalizer},
 					OwnerReferences: []metav1.OwnerReference{
 						{
 							APIVersion:         "ipam.cluster.x-k8s.io/v1alpha1",

--- a/internal/controllers/suite_test.go
+++ b/internal/controllers/suite_test.go
@@ -21,6 +21,7 @@ import (
 	//+kubebuilder:scaffold:imports
 	v1alpha1 "github.com/telekom/cluster-api-ipam-provider-in-cluster/api/v1alpha1"
 	"github.com/telekom/cluster-api-ipam-provider-in-cluster/internal/index"
+	"github.com/telekom/cluster-api-ipam-provider-in-cluster/pkg/ipamutil"
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -78,9 +79,10 @@ var _ = BeforeSuite(func() {
 	Expect(index.SetupIndexes(ctx, mgr)).To(Succeed())
 
 	Expect(
-		(&IPAddressClaimReconciler{
-			Client: mgr.GetClient(),
-			Scheme: mgr.GetScheme(),
+		(&ipamutil.ClaimReconciler{
+			Client:   mgr.GetClient(),
+			Scheme:   mgr.GetScheme(),
+			Provider: &InClusterProviderIntegration{},
 		}).SetupWithManager(ctx, mgr),
 	).To(Succeed())
 

--- a/main.go
+++ b/main.go
@@ -36,6 +36,7 @@ import (
 	"github.com/telekom/cluster-api-ipam-provider-in-cluster/internal/controllers"
 	"github.com/telekom/cluster-api-ipam-provider-in-cluster/internal/index"
 	"github.com/telekom/cluster-api-ipam-provider-in-cluster/internal/webhooks"
+	"github.com/telekom/cluster-api-ipam-provider-in-cluster/pkg/ipamutil"
 )
 
 var (
@@ -94,9 +95,14 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err = (&controllers.IPAddressClaimReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+	if err = (&ipamutil.ClaimReconciler{
+		Client:           mgr.GetClient(),
+		Scheme:           mgr.GetScheme(),
+		WatchFilterValue: watchFilter,
+		Provider: &controllers.InClusterProviderIntegration{
+			Client:           mgr.GetClient(),
+			WatchFilterValue: watchFilter,
+		},
 	}).SetupWithManager(ctx, mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "IPAddressClaim")
 		os.Exit(1)

--- a/pkg/ipamutil/address.go
+++ b/pkg/ipamutil/address.go
@@ -12,8 +12,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-// NewIPAddress creates a new ipamv1.IPAddress with references to a pool and claim.
-func NewIPAddress(claim *ipamv1.IPAddressClaim, pool client.Object) ipamv1.IPAddress {
+// newIPAddress creates a new ipamv1.IPAddress with references to a pool and claim.
+func newIPAddress(claim *ipamv1.IPAddressClaim, pool client.Object) ipamv1.IPAddress {
 	poolGVK := pool.GetObjectKind().GroupVersionKind()
 
 	return ipamv1.IPAddress{
@@ -34,9 +34,9 @@ func NewIPAddress(claim *ipamv1.IPAddressClaim, pool client.Object) ipamv1.IPAdd
 	}
 }
 
-// EnsureIPAddressOwnerReferences ensures that an IPAddress has the
+// ensureIPAddressOwnerReferences ensures that an IPAddress has the
 // IPAddressClaim and IPPool as an OwnerReference.
-func EnsureIPAddressOwnerReferences(scheme *runtime.Scheme, address *ipamv1.IPAddress, claim *ipamv1.IPAddressClaim, pool client.Object) error {
+func ensureIPAddressOwnerReferences(scheme *runtime.Scheme, address *ipamv1.IPAddress, claim *ipamv1.IPAddressClaim, pool client.Object) error {
 	if err := controllerutil.SetControllerReference(claim, address, scheme); err != nil {
 		if _, ok := err.(*controllerutil.AlreadyOwnedError); !ok {
 			return errors.Wrap(err, "Failed to update address's claim owner reference")

--- a/pkg/ipamutil/reconciler.go
+++ b/pkg/ipamutil/reconciler.go
@@ -1,0 +1,191 @@
+package ipamutil
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	ipamv1 "sigs.k8s.io/cluster-api/exp/ipam/api/v1alpha1"
+	clusterutil "sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/cluster-api/util/annotations"
+	"sigs.k8s.io/cluster-api/util/patch"
+	"sigs.k8s.io/cluster-api/util/predicates"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const (
+	// ReleaseAddressFinalizer is used to release an IP address before cleaning up the claim.
+	ReleaseAddressFinalizer = "ipam.cluster.x-k8s.io/ReleaseAddress"
+
+	// ProtectAddressFinalizer is used to prevent deletion of an IPAddress object while its claim is not deleted.
+	ProtectAddressFinalizer = "ipam.cluster.x-k8s.io/ProtectAddress"
+)
+
+// ClaimReconciler reconciles a IPAddressClaim object using a ProviderIntegration.
+type ClaimReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+
+	WatchFilterValue string
+
+	Provider ProviderIntegration
+}
+
+// ProviderIntegration is an interface that must be implemented by an IPAM provider.
+type ProviderIntegration interface {
+	// SetupWithManager allows the integration to configure the controller.
+	SetupWithManager(context.Context, *ctrl.Builder) error
+	// ClaimHandlerFor needs to return a ClaimHandler for the provider.
+	ClaimHandlerFor(client.Client, *ipamv1.IPAddressClaim) ClaimHandler
+}
+
+// ClaimHandler knows how to allocate and release IP addresses for a specific provider.
+type ClaimHandler interface {
+	FetchPool(ctx context.Context) (*ctrl.Result, error)
+	EnsureAddress(ctx context.Context, address *ipamv1.IPAddress) (*ctrl.Result, error)
+	ReleaseAddress() (*ctrl.Result, error)
+	GetPool() client.Object
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *ClaimReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
+	b := ctrl.NewControllerManagedBy(mgr).
+		WithEventFilter(predicates.ResourceNotPausedAndHasFilterLabel(ctrl.LoggerFrom(ctx), r.WatchFilterValue))
+
+	if err := r.Provider.SetupWithManager(ctx, b); err != nil {
+		return err
+	}
+	return b.Complete(r)
+}
+
+// Reconcile is called by the controller to reconcile a claim.
+func (r *ClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
+	log := ctrl.LoggerFrom(ctx)
+	log.Info("Reconciling claim")
+
+	// Fetch the IPAddressClaim
+	claim := &ipamv1.IPAddressClaim{}
+	if err := r.Get(ctx, req.NamespacedName, claim); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	cluster, err := clusterutil.GetClusterFromMetadata(ctx, r.Client, claim.ObjectMeta)
+	if err == nil {
+		if annotations.IsPaused(cluster, claim) {
+			log.Info("IPAddressClaim linked to a cluster that is paused")
+			return reconcile.Result{}, nil
+		}
+	}
+
+	// Create a patch helper for the claim.
+	patchHelper, err := patch.NewHelper(claim, r.Client)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	defer func() {
+		if err := patchHelper.Patch(ctx, claim); err != nil {
+			reterr = kerrors.NewAggregate([]error{reterr, err})
+		}
+	}()
+
+	// Ensure the claim has a finalizer.
+	controllerutil.AddFinalizer(claim, ReleaseAddressFinalizer)
+
+	// Create the provider handler and fetch the pool.
+	handler := r.Provider.ClaimHandlerFor(r.Client, claim)
+	if res, err := handler.FetchPool(ctx); err != nil || res != nil {
+		return unwrapResult(res), err
+	}
+
+	if annotations.HasPaused(handler.GetPool()) {
+		log.Info("IPAddressClaim references Pool which is paused, skipping reconciliation.", "IPAddressClaim", claim.GetName(), "Pool", handler.GetPool().GetName())
+		return ctrl.Result{}, nil
+	}
+
+	address := ipamv1.IPAddress{}
+	if err := r.Client.Get(ctx, req.NamespacedName, &address); err != nil && !apierrors.IsNotFound(err) {
+		return ctrl.Result{}, errors.Wrap(err, "failed to fetch address")
+	}
+
+	// If the claim is marked for deletion, release the address.
+	if !claim.ObjectMeta.DeletionTimestamp.IsZero() {
+		if res, err := handler.ReleaseAddress(); err != nil || res != nil {
+			return unwrapResult(res), err
+		}
+		return r.reconcileDelete(ctx, claim, &address)
+	}
+
+	// We always ensure there is a valid address object passed to the handler.
+	// The handler will complete it with the ip address.
+	if address.Name == "" {
+		address = newIPAddress(claim, handler.GetPool())
+	}
+
+	if res, err := handler.EnsureAddress(ctx, &address); err != nil || res != nil {
+		return unwrapResult(res), err
+	}
+
+	// Patch or create the address, ensuring necessary owner references are set.
+	operationResult, err := controllerutil.CreateOrPatch(ctx, r.Client, &address, func() error {
+		if err := ensureIPAddressOwnerReferences(r.Scheme, &address, claim, handler.GetPool()); err != nil {
+			return errors.Wrap(err, "failed to ensure owner references on address")
+		}
+
+		_ = controllerutil.AddFinalizer(&address, ProtectAddressFinalizer)
+
+		return nil
+	})
+	if err != nil {
+		return ctrl.Result{}, errors.Wrap(err, "failed to create or patch address")
+	}
+
+	log.Info(fmt.Sprintf("IPAddress %s/%s (%s) has been %s", address.Namespace, address.Name, address.Spec.Address, operationResult),
+		"IPAddressClaim", fmt.Sprintf("%s/%s", claim.Namespace, claim.Name))
+
+	if !address.DeletionTimestamp.IsZero() {
+		// We prevent deleting IPAddresses while their corresponding IPClaim still exists since we cannot guarantee that the IP
+		// wil remain the same when we recreate it.
+		log.Info("Address is marked for deletion, but deletion is prevented until the claim is deleted as well.", "address", address.Name)
+	}
+
+	claim.Status.AddressRef = corev1.LocalObjectReference{Name: address.Name}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *ClaimReconciler) reconcileDelete(ctx context.Context, claim *ipamv1.IPAddressClaim, address *ipamv1.IPAddress) (ctrl.Result, error) {
+	if address.Name != "" {
+		var err error
+		if controllerutil.RemoveFinalizer(address, ProtectAddressFinalizer) {
+			if err = r.Client.Update(ctx, address); err != nil && !apierrors.IsNotFound(err) {
+				return ctrl.Result{}, errors.Wrap(err, "failed to remove address finalizer")
+			}
+		}
+
+		if err == nil {
+			if err := r.Client.Delete(ctx, address); err != nil && !apierrors.IsNotFound(err) {
+				return ctrl.Result{}, err
+			}
+		}
+	}
+
+	controllerutil.RemoveFinalizer(claim, ReleaseAddressFinalizer)
+	return ctrl.Result{}, nil
+}
+
+func unwrapResult(res *ctrl.Result) ctrl.Result {
+	if res == nil {
+		return ctrl.Result{}
+	}
+	return *res
+}


### PR DESCRIPTION
This is an attempt to implement a generic `ClaimReconciler` that can be used by other IPAM providers as well. Most of the logic will probably be similar, with only the actual ip address allocation being provider specific. There are several benefits to this approach imo:

- When the ClaimReconciler is well tested, providers only need to implement specific cases (e.g. special conditions)
- It's a lot easier to ensure providers adhere to the IPAM contract. If everyone is using it, it would also be easier to change the contract.
- The ClaimHandler can be tested individually.

I'll validate the approach with the implementation of the infoblox provider I'm working on.

Ultimately this _could_ be moved to upstream CAPI.

@tylerschultz, @srm09 et. al - it would be great if you can have a look.