### PR TITLE
:bug: Migrate modules to right path

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -55,7 +55,7 @@ linters-settings:
     # Maximum length of variable declaration measured in number of characters, after which linter won't suggest using short syntax.
     max-decl-chars: 50
   gci:
-    local-prefixes: "github.com/telekom/cluster-api-ipam-provider-in-cluster"
+    local-prefixes: "sigs.k8s.io/cluster-api-ipam-provider-in-cluster"
   importas:
     no-unaliased: true
     alias:

--- a/PROJECT
+++ b/PROJECT
@@ -2,7 +2,7 @@ domain: cluster.x-k8s.io
 layout:
 - go.kubebuilder.io/v3
 projectName: cluster-api-ipam-provider-in-cluster
-repo: github.com/telekom/cluster-api-ipam-provider-in-cluster
+repo: sigs.k8s.io/cluster-api-ipam-provider-in-cluster
 resources:
 - api:
     crdVersion: v1
@@ -10,6 +10,6 @@ resources:
   controller: true
   group: ipam
   kind: InClusterIPPool
-  path: github.com/telekom/cluster-api-ipam-provider-in-cluster/api/v1alpha1
+  path: sigs.k8s.io/cluster-api-ipam-provider-in-cluster/api/v1alpha1
   version: v1alpha1
 version: "3"

--- a/README.md
+++ b/README.md
@@ -63,4 +63,4 @@ Unless required by applicable law or agreed to in writing, software distributed 
 
 ### Dependency Licenses
 
-You can find the licenses of used Go dependencies as a `licenses.tar.gz` archive as part of our [releases](https://github.com/telekom/cluster-api-ipam-provider-in-cluster/releases) and in the `/license` directory contained in our container images available at [ghcr.io/telekom/cluster-api-ipam-provider-in-cluster](https://ghcr.io/telekom/cluster-api-ipam-provider-in-cluster).
+You can find the licenses of used Go dependencies as a `licenses.tar.gz` archive as part of our [releases](https://github.com/kubernetes-sigs/cluster-api-ipam-provider-in-cluster/releases) and in the `/license` directory contained in our container images available at [ghcr.io/telekom/cluster-api-ipam-provider-in-cluster](https://ghcr.io/telekom/cluster-api-ipam-provider-in-cluster).

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/telekom/cluster-api-ipam-provider-in-cluster
+module sigs.k8s.io/cluster-api-ipam-provider-in-cluster
 
 go 1.19
 

--- a/hack/version.sh
+++ b/hack/version.sh
@@ -68,7 +68,7 @@ version::ldflags() {
         local key=${1}
         local val=${2}
         ldflags+=(
-            "-X 'github.com/telekom/cluster-api-ipam-provider-in-cluster/version.${key}=${val}'"
+            "-X 'sigs.k8s.io/cluster-api-ipam-provider-in-cluster/version.${key}=${val}'"
         )
     }
 

--- a/internal/controllers/inclusterippool.go
+++ b/internal/controllers/inclusterippool.go
@@ -36,9 +36,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
-	"github.com/telekom/cluster-api-ipam-provider-in-cluster/api/v1alpha1"
-	"github.com/telekom/cluster-api-ipam-provider-in-cluster/internal/poolutil"
-	pooltypes "github.com/telekom/cluster-api-ipam-provider-in-cluster/pkg/types"
+	"sigs.k8s.io/cluster-api-ipam-provider-in-cluster/api/v1alpha1"
+	"sigs.k8s.io/cluster-api-ipam-provider-in-cluster/internal/poolutil"
+	pooltypes "sigs.k8s.io/cluster-api-ipam-provider-in-cluster/pkg/types"
 )
 
 const (

--- a/internal/controllers/inclusterippool_test.go
+++ b/internal/controllers/inclusterippool_test.go
@@ -29,8 +29,8 @@ import (
 	ipamv1 "sigs.k8s.io/cluster-api/exp/ipam/api/v1alpha1"
 	. "sigs.k8s.io/controller-runtime/pkg/envtest/komega"
 
-	"github.com/telekom/cluster-api-ipam-provider-in-cluster/api/v1alpha1"
-	pooltypes "github.com/telekom/cluster-api-ipam-provider-in-cluster/pkg/types"
+	"sigs.k8s.io/cluster-api-ipam-provider-in-cluster/api/v1alpha1"
+	pooltypes "sigs.k8s.io/cluster-api-ipam-provider-in-cluster/pkg/types"
 )
 
 var _ = Describe("IP Pool Reconciler", func() {

--- a/internal/controllers/ipaddressclaim.go
+++ b/internal/controllers/ipaddressclaim.go
@@ -44,12 +44,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
-	"github.com/telekom/cluster-api-ipam-provider-in-cluster/api/v1alpha1"
-	"github.com/telekom/cluster-api-ipam-provider-in-cluster/internal/index"
-	"github.com/telekom/cluster-api-ipam-provider-in-cluster/internal/poolutil"
-	"github.com/telekom/cluster-api-ipam-provider-in-cluster/pkg/ipamutil"
-	ipampredicates "github.com/telekom/cluster-api-ipam-provider-in-cluster/pkg/predicates"
-	pooltypes "github.com/telekom/cluster-api-ipam-provider-in-cluster/pkg/types"
+	"sigs.k8s.io/cluster-api-ipam-provider-in-cluster/api/v1alpha1"
+	"sigs.k8s.io/cluster-api-ipam-provider-in-cluster/internal/index"
+	"sigs.k8s.io/cluster-api-ipam-provider-in-cluster/internal/poolutil"
+	"sigs.k8s.io/cluster-api-ipam-provider-in-cluster/pkg/ipamutil"
+	ipampredicates "sigs.k8s.io/cluster-api-ipam-provider-in-cluster/pkg/predicates"
+	pooltypes "sigs.k8s.io/cluster-api-ipam-provider-in-cluster/pkg/types"
 )
 
 const (

--- a/internal/controllers/ipaddressclaim_test.go
+++ b/internal/controllers/ipaddressclaim_test.go
@@ -30,7 +30,7 @@ import (
 	"sigs.k8s.io/cluster-api/util/patch"
 	. "sigs.k8s.io/controller-runtime/pkg/envtest/komega"
 
-	"github.com/telekom/cluster-api-ipam-provider-in-cluster/api/v1alpha1"
+	"sigs.k8s.io/cluster-api-ipam-provider-in-cluster/api/v1alpha1"
 )
 
 var IgnoreUIDsOnIPAddress = IgnorePaths{

--- a/internal/controllers/suite_test.go
+++ b/internal/controllers/suite_test.go
@@ -35,8 +35,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest/komega"
 
 	//+kubebuilder:scaffold:imports
-	v1alpha1 "github.com/telekom/cluster-api-ipam-provider-in-cluster/api/v1alpha1"
-	"github.com/telekom/cluster-api-ipam-provider-in-cluster/internal/index"
+	v1alpha1 "sigs.k8s.io/cluster-api-ipam-provider-in-cluster/api/v1alpha1"
+	"sigs.k8s.io/cluster-api-ipam-provider-in-cluster/internal/index"
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to

--- a/internal/poolutil/pool.go
+++ b/internal/poolutil/pool.go
@@ -31,8 +31,8 @@ import (
 	ipamv1 "sigs.k8s.io/cluster-api/exp/ipam/api/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/telekom/cluster-api-ipam-provider-in-cluster/api/v1alpha1"
-	"github.com/telekom/cluster-api-ipam-provider-in-cluster/internal/index"
+	"sigs.k8s.io/cluster-api-ipam-provider-in-cluster/api/v1alpha1"
+	"sigs.k8s.io/cluster-api-ipam-provider-in-cluster/internal/index"
 )
 
 // AddressesOutOfRangeIPSet returns an IPSet of the inUseAddresses IPs that are

--- a/internal/poolutil/pool_test.go
+++ b/internal/poolutil/pool_test.go
@@ -24,7 +24,7 @@ import (
 	. "github.com/onsi/gomega"
 	"go4.org/netipx"
 
-	"github.com/telekom/cluster-api-ipam-provider-in-cluster/api/v1alpha1"
+	"sigs.k8s.io/cluster-api-ipam-provider-in-cluster/api/v1alpha1"
 )
 
 var _ = Describe("AddressListToSet", func() {

--- a/internal/webhooks/inclusterippool.go
+++ b/internal/webhooks/inclusterippool.go
@@ -31,9 +31,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
-	"github.com/telekom/cluster-api-ipam-provider-in-cluster/api/v1alpha1"
-	"github.com/telekom/cluster-api-ipam-provider-in-cluster/internal/poolutil"
-	"github.com/telekom/cluster-api-ipam-provider-in-cluster/pkg/types"
+	"sigs.k8s.io/cluster-api-ipam-provider-in-cluster/api/v1alpha1"
+	"sigs.k8s.io/cluster-api-ipam-provider-in-cluster/internal/poolutil"
+	"sigs.k8s.io/cluster-api-ipam-provider-in-cluster/pkg/types"
 )
 
 const (

--- a/internal/webhooks/inclusterippool_test.go
+++ b/internal/webhooks/inclusterippool_test.go
@@ -29,9 +29,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	"github.com/telekom/cluster-api-ipam-provider-in-cluster/api/v1alpha1"
-	"github.com/telekom/cluster-api-ipam-provider-in-cluster/internal/index"
-	"github.com/telekom/cluster-api-ipam-provider-in-cluster/pkg/types"
+	"sigs.k8s.io/cluster-api-ipam-provider-in-cluster/api/v1alpha1"
+	"sigs.k8s.io/cluster-api-ipam-provider-in-cluster/internal/index"
+	"sigs.k8s.io/cluster-api-ipam-provider-in-cluster/pkg/types"
 )
 
 func TestPoolDeletionWithExistingIPAddresses(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -33,10 +33,10 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 
-	"github.com/telekom/cluster-api-ipam-provider-in-cluster/api/v1alpha1"
-	"github.com/telekom/cluster-api-ipam-provider-in-cluster/internal/controllers"
-	"github.com/telekom/cluster-api-ipam-provider-in-cluster/internal/index"
-	"github.com/telekom/cluster-api-ipam-provider-in-cluster/internal/webhooks"
+	"sigs.k8s.io/cluster-api-ipam-provider-in-cluster/api/v1alpha1"
+	"sigs.k8s.io/cluster-api-ipam-provider-in-cluster/internal/controllers"
+	"sigs.k8s.io/cluster-api-ipam-provider-in-cluster/internal/index"
+	"sigs.k8s.io/cluster-api-ipam-provider-in-cluster/internal/webhooks"
 )
 
 var (

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -20,7 +20,7 @@ package types
 import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/telekom/cluster-api-ipam-provider-in-cluster/api/v1alpha1"
+	"sigs.k8s.io/cluster-api-ipam-provider-in-cluster/api/v1alpha1"
 )
 
 // GenericInClusterPool is a common interface for InClusterIPPool and GlobalInClusterIPPool.


### PR DESCRIPTION
**What this PR does / why we need it**:
Today the code was migrated keeping the old reference to the original repo. This becomes a problem while trying to use/import some helper functions, etc :)
