### PR TITLE
🌱 Add `categories=cluster-api` to the crd

### DIFF
--- a/api/v1alpha1/inclusterippool_types.go
+++ b/api/v1alpha1/inclusterippool_types.go
@@ -85,6 +85,7 @@ type InClusterIPPoolStatusIPAddresses struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:deprecatedversion
+// +kubebuilder:resource:categories=cluster-api
 // +kubebuilder:printcolumn:name="Subnet",type="string",JSONPath=".spec.subnet",description="Subnet to allocate IPs from"
 // +kubebuilder:printcolumn:name="First",type="string",JSONPath=".spec.first",description="First address of the range to allocate from"
 // +kubebuilder:printcolumn:name="Last",type="string",JSONPath=".spec.last",description="Last address of the range to allocate from"
@@ -114,7 +115,7 @@ type InClusterIPPoolList struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:deprecatedversion
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:scope=Cluster,categories=cluster-api
 // +kubebuilder:printcolumn:name="Subnet",type="string",JSONPath=".spec.subnet",description="Subnet to allocate IPs from"
 // +kubebuilder:printcolumn:name="First",type="string",JSONPath=".spec.first",description="First address of the range to allocate from"
 // +kubebuilder:printcolumn:name="Last",type="string",JSONPath=".spec.last",description="Last address of the range to allocate from"

--- a/api/v1alpha2/inclusterippool_types.go
+++ b/api/v1alpha2/inclusterippool_types.go
@@ -78,6 +78,7 @@ type InClusterIPPoolStatusIPAddresses struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
+// +kubebuilder:resource:categories=cluster-api
 // +kubebuilder:printcolumn:name="Addresses",type="string",JSONPath=".spec.addresses",description="List of addresses, to allocate from"
 // +kubebuilder:printcolumn:name="Total",type="integer",JSONPath=".status.ipAddresses.total",description="Count of IPs configured for the pool"
 // +kubebuilder:printcolumn:name="Free",type="integer",JSONPath=".status.ipAddresses.free",description="Count of unallocated IPs in the pool"
@@ -104,7 +105,7 @@ type InClusterIPPoolList struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:scope=Cluster,categories=cluster-api
 // +kubebuilder:printcolumn:name="Addresses",type="string",JSONPath=".spec.addresses",description="List of addresses, to allocate from"
 // +kubebuilder:printcolumn:name="Total",type="integer",JSONPath=".status.ipAddresses.total",description="Count of IPs configured for the pool"
 // +kubebuilder:printcolumn:name="Free",type="integer",JSONPath=".status.ipAddresses.free",description="Count of unallocated IPs in the pool"

--- a/config/crd/bases/ipam.cluster.x-k8s.io_globalinclusterippools.yaml
+++ b/config/crd/bases/ipam.cluster.x-k8s.io_globalinclusterippools.yaml
@@ -10,6 +10,8 @@ metadata:
 spec:
   group: ipam.cluster.x-k8s.io
   names:
+    categories:
+    - cluster-api
     kind: GlobalInClusterIPPool
     listKind: GlobalInClusterIPPoolList
     plural: globalinclusterippools

--- a/config/crd/bases/ipam.cluster.x-k8s.io_inclusterippools.yaml
+++ b/config/crd/bases/ipam.cluster.x-k8s.io_inclusterippools.yaml
@@ -10,6 +10,8 @@ metadata:
 spec:
   group: ipam.cluster.x-k8s.io
   names:
+    categories:
+    - cluster-api
     kind: InClusterIPPool
     listKind: InClusterIPPoolList
     plural: inclusterippools


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This PR adds the category `cluster-api` to the custom resource definitions.

By doing that it follows the prior art in core CAPI and providers to populate the category field.

By this change a `kubectl get cluster-api` query will also output this CRs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
