### PR TITLE
⚠️ align prefix of deployments with image name

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,18 +1,18 @@
 # Adds namespace to all resources.
-namespace: caip-in-cluster-system
+namespace: capi-ipam-in-cluster-system
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named
 # "wordpress" becomes "alices-wordpress".
 # Note that it should also match with the prefix (text before '-') of the namespace
 # field above.
-namePrefix: caip-in-cluster-
+namePrefix: capi-ipam-in-cluster-
 
 # Labels to add to all resources and selectors.
 commonLabels:
   cluster.x-k8s.io/provider: "ipam-in-cluster"
 
-bases:
+resources:
 - ../crd
 - ../rbac
 - ../manager

--- a/config/default/manager_webhook_patch.yaml
+++ b/config/default/manager_webhook_patch.yaml
@@ -19,4 +19,4 @@ spec:
       volumes:
       - name: cert
         secret:
-          secretName: caip-in-cluster-webhook-service-cert
+          secretName: capi-ipam-in-cluster-webhook-service-cert

--- a/tilt-provider.yaml
+++ b/tilt-provider.yaml
@@ -10,4 +10,4 @@ config:
   - internal
   - pkg
   label: "IPAM-in-cluster"
-  manager-name: "caip-in-cluster-controller-manager"
+  manager-name: "capi-ipam-in-cluster-controller-manager"


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Replaces the `caip-in-cluster` prefix with `capi-ipam-in-cluster` to be in line with the future image name. It was pointed out that caip just looks like a misspelling of capi.

I think this will lead to issues when upgrading existing deployments with clusterctl and would require to manually uninstall the provider first.
