### PR TITLE
Ensure IPAddress has a ClusterName label as CAPI resources

### DIFF
--- a/internal/controllers/ipaddressclaim_test.go
+++ b/internal/controllers/ipaddressclaim_test.go
@@ -91,7 +91,10 @@ var _ = Describe("IPAddressClaimReconciler", func() {
 		})
 
 		When("the referenced namespaced pool exists", func() {
-			const poolName = "test-pool"
+			const (
+				clusterName = "test-cluster"
+				poolName    = "test-pool"
+			)
 
 			BeforeEach(func() {
 				pool := v1alpha2.InClusterIPPool{
@@ -116,6 +119,7 @@ var _ = Describe("IPAddressClaimReconciler", func() {
 
 			It("should allocate an Address from the Pool", func() {
 				claim := newClaim("test", namespace, "InClusterIPPool", poolName)
+				claim.Labels = map[string]string{clusterv1.ClusterNameLabel: clusterName}
 				expectedIPAddress := ipamv1.IPAddress{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       "test",
@@ -137,6 +141,7 @@ var _ = Describe("IPAddressClaimReconciler", func() {
 								Name:               poolName,
 							},
 						},
+						Labels: map[string]string{clusterv1.ClusterNameLabel: clusterName},
 					},
 					Spec: ipamv1.IPAddressSpec{
 						ClaimRef: corev1.LocalObjectReference{


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
CAPI has a contract to label all created resources with a ClusterName label. CAPV will label IPAddressClaim. This PR is to ensure IPAddress also got one.

Please find more discussion in https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/issues/2218

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
