### PR TITLE
🌱 Update to current preferred config directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ IPAM providers allow to control how IP addresses are assigned to Cluster API Mac
 
 ## Setup via clusterctl
 
-This provider comes with clusterctl support. Since it's not added to the built-in list of providers yet, you'll need to add the following to your `~/.cluster-api/clusterctl.yaml` if you want to install it using `clusterctl init --ipam in-cluster`:
+This provider comes with clusterctl support. Since it's not added to the built-in list of providers yet, you'll need to add the following to your `$XDG_CONFIG_HOME/cluster-api/clusterctl.yaml` if you want to install it using `clusterctl init --ipam in-cluster`:
 
 ```yaml
 providers:


### PR DESCRIPTION
**What this PR does / why we need it**:

The README docs mention the older `~/.cluster-api` configuration directory for accessing the clusterctl.yaml file. This should now point to `$XDG_CONFIG_HOME/cluster-api` instead.

**Which issue(s) this PR fixes**:

N/A
