### PR TITLE
🐛 align image name with other capi providers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Image URL to use all building/pushing image targets
-IMG ?= gcr.io/k8s-staging-capi-ipam-ic/cluster-api-ipam-provider-in-cluster
+IMG ?= gcr.io/k8s-staging-capi-ipam-ic/cluster-api-ipam-provider-in-cluster-controller
 TAG ?= dev
 # PULL_BASE_REF is set by prow and contains the git ref for a build, e.g. branch name or tag
 RELEASE_ALIAS_TAG ?= $(PULL_BASE_REF)


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Appends `-controller` to image name to align it with other providers. Not considered a breaking change since we've never published images on the official registries for this project.
