### PR TITLE
🌱 use registry.k8s.io image in release manifests

### DIFF
--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -7,6 +7,6 @@ spec:
   template:
     spec:
       containers:
-      - image: ghcr.io/telekom/cluster-api-ipam-provider-in-cluster:main
+      - name: manager
+        image: gcr.io/k8s-staging-capi-ipam-ic/cluster-api-ipam-in-cluster-controller:dev
         imagePullPolicy: Always
-        name: manager


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Replaces the images in release manifests with registry.k8s.io ones as we're now able to use those.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
