### PR TITLE
:warning: ReleaseAddress should receive a context

### DIFF
--- a/internal/controllers/ipaddressclaim.go
+++ b/internal/controllers/ipaddressclaim.go
@@ -227,7 +227,7 @@ func (h *IPAddressClaimHandler) EnsureAddress(ctx context.Context, address *ipam
 }
 
 // ReleaseAddress releases the ip address.
-func (h *IPAddressClaimHandler) ReleaseAddress() (*ctrl.Result, error) {
+func (h *IPAddressClaimHandler) ReleaseAddress(_ context.Context) (*ctrl.Result, error) {
 	// We don't need to do anything here, since the ip address is released when the IPAddress is deleted
 	return nil, nil
 }

--- a/pkg/ipamutil/reconciler.go
+++ b/pkg/ipamutil/reconciler.go
@@ -72,7 +72,7 @@ type ClaimHandler interface {
 	// EnsureAddress is called to make sure that the IPAddress.Spec is correct and the address is allocated.
 	EnsureAddress(ctx context.Context, address *ipamv1.IPAddress) (*ctrl.Result, error)
 	// ReleaseAddress is called to release the ip address that was allocated for the claim.
-	ReleaseAddress() (*ctrl.Result, error)
+	ReleaseAddress(ctx context.Context) (*ctrl.Result, error)
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -188,7 +188,7 @@ func (r *ClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ct
 
 	// If the claim is marked for deletion, release the address.
 	if !claim.ObjectMeta.DeletionTimestamp.IsZero() {
-		if res, err := handler.ReleaseAddress(); err != nil {
+		if res, err := handler.ReleaseAddress(ctx); err != nil {
 			return unwrapResult(res), err
 		}
 		return ctrl.Result{}, r.reconcileDelete(ctx, claim)


### PR DESCRIPTION
**What this PR does / why we need it**: The interface for ClaimHandler does not request a context on ReleaseAddress method.

We need the context here, as to get/use the Kubernetes client, and any other client (eg. an IPAM HTTP Rest API) during the release we may need the current context. 

**Note**: This is marked as a Warning/Breaking change, because we are changing a public interface
