### PR TITLE
🌱 Introduce Metric as infospec on Gateways

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,20 @@ spec:
   allocateReservedIPAddresses: true
 ```
 
+To support using the `gateway` field as a default route, a metric can be added for informational purposes. 
+
+```yaml
+apiVersion: ipam.cluster.x-k8s.io/v1alpha2
+kind: InClusterIPPool
+metadata:
+  name: inclusterippool-sample
+spec:
+  addresses:
+    - 10.0.0.0/24
+  prefix: 24
+  gateway: 10.0.0.1
+  metric: 100
+```
 
 ## Community, discussion, contribution, and support
 

--- a/api/v1alpha1/zz_generated.conversion.go
+++ b/api/v1alpha1/zz_generated.conversion.go
@@ -270,6 +270,7 @@ func autoConvert_v1alpha2_InClusterIPPoolSpec_To_v1alpha1_InClusterIPPoolSpec(in
 	out.Addresses = *(*[]string)(unsafe.Pointer(&in.Addresses))
 	out.Prefix = in.Prefix
 	out.Gateway = in.Gateway
+	// WARNING: in.Metric requires manual conversion: does not exist in peer-type
 	// WARNING: in.AllocateReservedIPAddresses requires manual conversion: does not exist in peer-type
 	// WARNING: in.ExcludedAddresses requires manual conversion: does not exist in peer-type
 	return nil

--- a/api/v1alpha2/inclusterippool_types.go
+++ b/api/v1alpha2/inclusterippool_types.go
@@ -34,6 +34,10 @@ type InClusterIPPoolSpec struct {
 	// +optional
 	Gateway string `json:"gateway,omitempty"`
 
+	// Metric is the priority applied to a gateway route
+	// +optional
+	Metric *uint32 `json:"metric,omitempty"`
+
 	// AllocateReservedIPAddresses causes the provider to allocate the network
 	// address (the first address in the inferred subnet) and broadcast address
 	// (the last address in the inferred subnet) when IPv4. The provider will

--- a/api/v1alpha2/zz_generated.deepcopy.go
+++ b/api/v1alpha2/zz_generated.deepcopy.go
@@ -150,6 +150,11 @@ func (in *InClusterIPPoolSpec) DeepCopyInto(out *InClusterIPPoolSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.Metric != nil {
+		in, out := &in.Metric, &out.Metric
+		*out = new(uint32)
+		**out = **in
+	}
 	if in.ExcludedAddresses != nil {
 		in, out := &in.ExcludedAddresses, &out.ExcludedAddresses
 		*out = make([]string, len(*in))

--- a/config/crd/bases/ipam.cluster.x-k8s.io_globalinclusterippools.yaml
+++ b/config/crd/bases/ipam.cluster.x-k8s.io_globalinclusterippools.yaml
@@ -214,6 +214,10 @@ spec:
               gateway:
                 description: Gateway
                 type: string
+              metric:
+                description: Metric is the priority applied to a gateway route
+                format: int32
+                type: integer
               prefix:
                 description: Prefix is the network prefix to use.
                 maximum: 128

--- a/config/crd/bases/ipam.cluster.x-k8s.io_inclusterippools.yaml
+++ b/config/crd/bases/ipam.cluster.x-k8s.io_inclusterippools.yaml
@@ -212,6 +212,10 @@ spec:
               gateway:
                 description: Gateway
                 type: string
+              metric:
+                description: Metric is the priority applied to a gateway route
+                format: int32
+                type: integer
               prefix:
                 description: Prefix is the network prefix to use.
                 maximum: 128


### PR DESCRIPTION
**What this PR does / why we need it**:
The api holds a Gateway string. We're using this in our `cluster-api-provider-proxmox` to create a default route (via netplan in bootstrap). We do happen to sometimes have multiple default gateways. In this case it'd be advantageous to transport a  metric with a default gateway. For this reason, I've added such a thing.

Routes in linux (and win32) fit into unsigned 32 bit integers, as such, neither validation nor testing is required. I've also made it a pointer so it can be nil.

A more complete implementation would require changing the API. I.e.: a network can have multiple gateways, with each one having an info spec, and the info spec being of considerable size: https://man7.org/linux/man-pages/man8/ip-route.8.html#SYNOPSIS .

An alternative would be to remove the gateway field altogether (it serves no purpose over exclusions, really) and instead create a fully featured gateway resource which has an ipam resource object as a parent, but I much prefer this minimal change.