### PR TITLE
🐛 Fix image reference in tilt-provider.yaml

### DIFF
--- a/tilt-provider.yaml
+++ b/tilt-provider.yaml
@@ -1,6 +1,6 @@
 name: "ipam-in-cluster"
 config:
-  image: "ghcr.io/telekom/cluster-api-ipam-provider-in-cluster"
+  image: "gcr.io/k8s-staging-capi-ipam-ic/cluster-api-ipam-in-cluster-controller"
   live_reload_deps:
   - main.go
   - go.mod


### PR DESCRIPTION
- This is a small fix to be able to use tilt in other project referring to this project.

While testing cluster-api-proxmox (which has tilt reference to this project), I found that tilt was not able to build this provider.  Digging into it I found that the image reference was changed from "telekom" to "k8s-staging-capi-ipam-ic". However, this reference was not updated. @schrej can you perhaps acknowledge that this is the correct fix?  
