### PR TITLE
🌱 upgrade golangci-lint and it's config and make it happy

### DIFF
--- a/.github/workflows/pullrequests.yaml
+++ b/.github/workflows/pullrequests.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6.1.0
         with:
-          version: v1.55.2
+          version: v1.60.2
 
   test:
     name: test

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,41 +1,59 @@
+run:
+  timeout: 10m
+  go: "1.22"
+  build-tags:
+    - e2e
+  allow-parallel-runners: true
+
 linters:
   disable-all: true
   enable:
-  - asciicheck
-  - bodyclose
-  - containedctx
-  - dogsled
-  - errcheck
-  - exportloopref
-  - gci
-  - goconst
-  - gocritic
-  - godot
-  - gofmt
-  - goimports
-  - goprintffuncname
-  - gosec
-  - gosimple
-  - govet
-  - importas
-  - ineffassign
-  - misspell
-  - nakedret
-  - nilerr
-  - noctx
-  - nolintlint
-  - prealloc
-  - predeclared
-  - revive
-  - rowserrcheck
-  - staticcheck
-  - stylecheck
-  - thelper
-  - typecheck
-  - unconvert
-  - unparam
-  - unused
-  - whitespace
+    - asasalint
+    - asciicheck
+    - bidichk
+    - bodyclose
+    - containedctx
+    - copyloopvar
+    - dogsled
+    - dupword
+    - durationcheck
+    - errcheck
+    - errchkjson
+    - gci
+    - ginkgolinter
+    - goconst
+    - gocritic
+    - godot
+    - gofmt
+    - goimports
+    - goprintffuncname
+    - gosec
+    - gosimple
+    - govet
+    - importas
+    - ineffassign
+    - intrange
+    - loggercheck
+    - misspell
+    - nakedret
+    - nilerr
+    - noctx
+    - nolintlint
+    - nosprintfhostport
+    - prealloc
+    - predeclared
+    - revive
+    - rowserrcheck
+    - staticcheck
+    - stylecheck
+    - tenv
+    - thelper
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - usestdlibvars
+    - whitespace
 
 linters-settings:
   godot:
@@ -46,11 +64,31 @@ linters-settings:
     exclude:
     - '^ \+.*'
     - '^ ANCHOR.*'
-  ifshort:
-    # Maximum length of variable declaration measured in number of characters, after which linter won't suggest using short syntax.
-    max-decl-chars: 50
   gci:
-    local-prefixes: "sigs.k8s.io/cluster-api-ipam-provider-in-cluster"
+    sections:
+      - standard
+      - default
+      - 'prefix(sigs.k8s.io/cluster-api-ipam-provider-in-cluster)'
+    custom-order: true
+  ginkgolinter:
+    forbid-focus-container: true
+  gocritic:
+    enabled-tags:
+      - experimental
+    disabled-checks:
+      - appendAssign
+      - dupImport # https://github.com/go-critic/go-critic/issues/845
+      - evalOrder
+      - ifElseChain
+      - octalLiteral
+      - regexpSimplify
+      - sloppyReassign
+      - truncateCmp
+      - typeDefFirst
+      - unnamedResult
+      - unnecessaryDefer
+      - whyNoLint
+      - wrapperFunc
   importas:
     no-unaliased: true
     alias:
@@ -82,134 +120,137 @@ linters-settings:
     allow-unused: false
     allow-leading-space: false
     require-specific: true
-  staticcheck:
-    go: "1.18"
-  stylecheck:
-    go: "1.18"
-  gosec:
-    excludes:
-    - G307 # Deferring unsafe method "Close" on type "\*os.File"
-    - G108 # Profiling endpoint is automatically exposed on /debug/pprof
-  gocritic:
-    enabled-tags:
-      - experimental
-    disabled-checks:
-    - appendAssign
-    - dupImport # https://github.com/go-critic/go-critic/issues/845
-    - evalOrder
-    - ifElseChain
-    - octalLiteral
-    - regexpSimplify
-    - sloppyReassign
-    - truncateCmp
-    - typeDefFirst
-    - unnamedResult
-    - unnecessaryDefer
-    - whyNoLint
-    - wrapperFunc
-  unused:
-    go: "1.18"
+  revive:
+    rules:
+      # The following rules are recommended https://github.com/mgechev/revive#recommended-configuration
+      - name: blank-imports
+      - name: context-as-argument
+      - name: context-keys-type
+      - name: dot-imports
+      - name: error-return
+      - name: error-strings
+      - name: error-naming
+      - name: exported
+      - name: if-return
+      - name: increment-decrement
+      - name: var-naming
+      - name: var-declaration
+      - name: package-comments
+      - name: range
+      - name: receiver-naming
+      - name: time-naming
+      - name: unexported-return
+      - name: indent-error-flow
+      - name: errorf
+      - name: empty-block
+      - name: superfluous-else
+      - name: unused-parameter
+      - name: unreachable-code
+      - name: redefines-builtin-id
+      #
+      # Rules in addition to the recommended configuration above.
+      #
+      - name: bool-literal-in-expr
+      - name: constant-logical-expr
+#  gosec:
+#    excludes:
+#    - G307 # Deferring unsafe method "Close" on type "\*os.File"
+#    - G108 # Profiling endpoint is automatically exposed on /debug/pprof
+  goconst:
+    ignore-tests: true
 issues:
   max-same-issues: 0
   max-issues-per-linter: 0
+
+  exclude-files:
+    - "zz_generated.*\\.go$"
+    - "vendored_openapi\\.go$"
+    - "api/.*/conversion\\.go$"
+  exclude-dirs:
+    - third_party
+
   # We are disabling default golangci exclusions because we want to help reviewers to focus on reviewing the most relevant
   # changes in PRs and avoid nitpicking.
   exclude-use-default: false
   exclude-rules:
-  - linters:
-    - revive
-    text: "exported: exported method .*\\.(Reconcile|SetupWithManager|SetupWebhookWithManager) should have comment or be unexported"
-  - linters:
-    - errcheck
-    text: Error return value of .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*print(f|ln)?|os\.(Un)?Setenv). is not checked
-  # Exclude some packages or code to require comments, for example test code, or fake clients.
-  - linters:
-    - revive
-    text: exported (method|function|type|const) (.+) should have comment or be unexported
-    source: (func|type).*Fake.*
-  - linters:
-    - revive
-    text: exported (method|function|type|const) (.+) should have comment or be unexported
-    path: fake_\.go
-  - linters:
-    - revive
-    text: exported (method|function|type|const) (.+) should have comment or be unexported
-    path: cmd/clusterctl/internal/test/providers.*.go
-  - linters:
-    - revive
-    text: exported (method|function|type|const) (.+) should have comment or be unexported
-    path: "(framework|e2e)/.*.go"
-  # Disable unparam "always receives" which might not be really
-  # useful when building libraries.
-  - linters:
-    - unparam
-    text: always receives
-  # Dot imports for gomega or ginkgo are allowed
-  # within test files.
-  - path: _test\.go
-    text: should not use dot imports
-  - path: (framework|e2e)/.*.go
-    text: should not use dot imports
-  - path: _test\.go
-    text: cyclomatic complexity
-  # Append should be able to assign to a different var/slice.
-  - linters:
-    - gocritic
-    text: "appendAssign: append result not assigned to the same slice"
-  # ifshort flags variables that are only used in the if-statement even though there is
-  # already a SimpleStmt being used in the if-statement in question.
-  - linters:
-    - ifshort
-    text: "variable .* is only used in the if-statement"
-    path: controllers/mdutil/util.go
-  # Disable linters for conversion
-  - linters:
-    - staticcheck
-    text: "SA1019: in.(.+) is deprecated"
-    path: .*(api|types)\/.*\/conversion.*\.go$
-  - linters:
-    - revive
-    text: exported (method|function|type|const) (.+) should have comment or be unexported
-    path: .*(api|types|test)\/.*\/conversion.*\.go$
-  - linters:
-    - revive
-    text: "var-naming: don't use underscores in Go names;"
-    path: .*(api|types|test)\/.*\/conversion.*\.go$
-  - linters:
-    - revive
-    text: "receiver-naming: receiver name"
-    path: .*(api|types)\/.*\/conversion.*\.go$
-  - linters:
-    - stylecheck
-    text: "ST1003: should not use underscores in Go names;"
-    path: .*(api|types|test)\/.*\/conversion.*\.go$
-  - linters:
-    - stylecheck
-    text: "ST1016: methods on the same type should have the same receiver name"
-    path: .*(api|types)\/.*\/conversion.*\.go$
-  # TODO(sbueringer) Ignore ifshort false positive: https://github.com/esimonov/ifshort/issues/23
-  - linters:
-    - ifshort
-    text:  "variable 'isDeleteNodeAllowed' is only used in the if-statement.*"
-    path: ^internal/controllers/machine/machine_controller\.go$
-  - linters:
-    - ifshort
-    text: "variable 'kcpMachinesWithErrors' is only used in the if-statement.*"
-    path: ^controlplane/kubeadm/internal/workload_cluster_conditions\.go$
-  # We don't care about defer in for loops in test files.
-  - linters:
-    - gocritic
-    text: "deferInLoop: Possible resource leak, 'defer' is called in the 'for' loop"
-    path: _test\.go
-
-run:
-  timeout: 10m
-  build-tags:
-  - e2e
-  skip-files:
-  - "zz_generated.*\\.go$"
-  - "vendored_openapi\\.go$"
-  - "api/.*/conversion\\.go$"
-  skip-dirs:
-  - third_party
-  allow-parallel-runners: true
+    - linters:
+        - revive
+      text: "exported: exported method .*\\.(Reconcile|SetupWithManager|SetupWebhookWithManager) should have comment or be unexported"
+    - linters:
+        - errcheck
+      text: Error return value of .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*print(f|ln)?|os\.(Un)?Setenv). is not checked
+    # Exclude some packages or code to require comments, for example test code, or fake clients.
+    - linters:
+        - revive
+      text: exported (method|function|type|const) (.+) should have comment or be unexported
+      source: (func|type).*Fake.*
+    - linters:
+        - revive
+      text: exported (method|function|type|const) (.+) should have comment or be unexported
+      path: fake_\.go
+    - linters:
+        - revive
+      text: exported (method|function|type|const) (.+) should have comment or be unexported
+      path: cmd/clusterctl/internal/test/providers.*.go
+    - linters:
+        - revive
+      text: exported (method|function|type|const) (.+) should have comment or be unexported
+      path: "(framework|e2e)/.*.go"
+    # Disable unparam "always receives" which might not be really
+    # useful when building libraries.
+    - linters:
+        - unparam
+      text: always receives
+    # Dot imports for gomega and ginkgo are allowed
+    # within test files and test utils.
+    - linters:
+        - revive
+        - stylecheck
+      path: _test\.go
+      text: should not use dot imports
+    # Append should be able to assign to a different var/slice.
+    - linters:
+        - gocritic
+      text: "appendAssign: append result not assigned to the same slice"
+    # Disable linters for conversion
+    - linters:
+        - staticcheck
+      text: "SA1019: in.(.+) is deprecated"
+      path: .*(api|types)\/.*\/conversion.*\.go$
+    - linters:
+        - revive
+      # Checking if an error is nil to just after return the error or nil is redundant
+      text: "if-return: redundant if ...; err != nil check, just return error instead"
+      # Ignoring stylistic checks for generated code
+      path: .*(api|types|test)\/.*\/conversion.*\.go$
+    - linters:
+        - revive
+      # Exported function and methods should have comments. This warns on undocumented exported functions and methods.
+      text: exported (method|function|type|const) (.+) should have comment or be unexported
+      # Ignoring stylistic checks for generated code
+      path: .*(api|types|test)\/.*\/conversion.*\.go$
+    - linters:
+        - revive
+      # This rule warns when initialism, variable or package naming conventions are not followed.
+      text: "var-naming: don't use underscores in Go names;"
+      # Ignoring stylistic checks for generated code
+      path: .*(api|types|test)\/.*\/conversion.*\.go$
+    - linters:
+        - revive
+      # By convention, receiver names in a method should reflect their identity.
+      text: "receiver-naming: receiver name"
+      # Ignoring stylistic checks for generated code
+      path: .*(api|types)\/.*\/conversion.*\.go$
+    - linters:
+        - stylecheck
+      text: "ST1003: should not use underscores in Go names;"
+      path: .*(api|types|test)\/.*\/conversion.*\.go$
+    - linters:
+        - stylecheck
+      text: "ST1016: methods on the same type should have the same receiver name"
+      path: .*(api|types)\/.*\/conversion.*\.go$
+    # We don't care about defer in for loops in test files.
+    - linters:
+        - gocritic
+      text: "deferInLoop: Possible resource leak, 'defer' is called in the 'for' loop"
+      path: _test\.go

--- a/api/v1alpha1/inclusterippool_types.go
+++ b/api/v1alpha1/inclusterippool_types.go
@@ -125,7 +125,7 @@ type InClusterIPPoolList struct {
 
 // GlobalInClusterIPPool is the Schema for the global inclusterippools API.
 // This pool type is cluster scoped. IPAddressClaims can reference
-// pools of this type from any any namespace.
+// pools of this type from any namespace.
 type GlobalInClusterIPPool struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1alpha2/inclusterippool_types.go
+++ b/api/v1alpha2/inclusterippool_types.go
@@ -37,7 +37,7 @@ type InClusterIPPoolSpec struct {
 	// AllocateReservedIPAddresses causes the provider to allocate the network
 	// address (the first address in the inferred subnet) and broadcast address
 	// (the last address in the inferred subnet) when IPv4. The provider will
-	// allocate the anycast address address (the first address in the inferred
+	// allocate the anycast address (the first address in the inferred
 	// subnet) when IPv6.
 	// +optional
 	AllocateReservedIPAddresses bool `json:"allocateReservedIPAddresses,omitempty"`
@@ -113,7 +113,7 @@ type InClusterIPPoolList struct {
 
 // GlobalInClusterIPPool is the Schema for the global inclusterippools API.
 // This pool type is cluster scoped. IPAddressClaims can reference
-// pools of this type from any any namespace.
+// pools of this type from any namespace.
 type GlobalInClusterIPPool struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/config/crd/bases/ipam.cluster.x-k8s.io_globalinclusterippools.yaml
+++ b/config/crd/bases/ipam.cluster.x-k8s.io_globalinclusterippools.yaml
@@ -48,7 +48,7 @@ spec:
         description: |-
           GlobalInClusterIPPool is the Schema for the global inclusterippools API.
           This pool type is cluster scoped. IPAddressClaims can reference
-          pools of this type from any any namespace.
+          pools of this type from any namespace.
         properties:
           apiVersion:
             description: |-
@@ -167,7 +167,7 @@ spec:
         description: |-
           GlobalInClusterIPPool is the Schema for the global inclusterippools API.
           This pool type is cluster scoped. IPAddressClaims can reference
-          pools of this type from any any namespace.
+          pools of this type from any namespace.
         properties:
           apiVersion:
             description: |-
@@ -201,7 +201,7 @@ spec:
                   AllocateReservedIPAddresses causes the provider to allocate the network
                   address (the first address in the inferred subnet) and broadcast address
                   (the last address in the inferred subnet) when IPv4. The provider will
-                  allocate the anycast address address (the first address in the inferred
+                  allocate the anycast address (the first address in the inferred
                   subnet) when IPv6.
                 type: boolean
               excludedAddresses:

--- a/config/crd/bases/ipam.cluster.x-k8s.io_inclusterippools.yaml
+++ b/config/crd/bases/ipam.cluster.x-k8s.io_inclusterippools.yaml
@@ -199,7 +199,7 @@ spec:
                   AllocateReservedIPAddresses causes the provider to allocate the network
                   address (the first address in the inferred subnet) and broadcast address
                   (the last address in the inferred subnet) when IPv4. The provider will
-                  allocate the anycast address address (the first address in the inferred
+                  allocate the anycast address (the first address in the inferred
                   subnet) when IPv6.
                 type: boolean
               excludedAddresses:

--- a/internal/controllers/inclusterippool_test.go
+++ b/internal/controllers/inclusterippool_test.go
@@ -65,7 +65,7 @@ var _ = Describe("IP Pool Reconciler", func() {
 				Expect(genericPool.PoolStatus().Addresses.Used).To(Equal(0))
 				Expect(genericPool.PoolStatus().Addresses.Free).To(Equal(expectedTotal))
 
-				for i := 0; i < expectedUsed; i++ {
+				for i := range expectedUsed {
 					claim := newClaim(fmt.Sprintf("test%d", i), namespace, poolType, genericPool.GetName())
 					Expect(k8sClient.Create(context.Background(), &claim)).To(Succeed())
 					createdClaimNames = append(createdClaimNames, claim.Name)
@@ -140,7 +140,7 @@ var _ = Describe("IP Pool Reconciler", func() {
 
 				Expect(k8sClient.Create(context.Background(), genericPool)).To(Succeed())
 
-				for i := 0; i < numClaims; i++ {
+				for i := range numClaims {
 					claim := newClaim(fmt.Sprintf("test%d", i), namespace, poolType, genericPool.GetName())
 					Expect(k8sClient.Create(context.Background(), &claim)).To(Succeed())
 					createdClaimNames = append(createdClaimNames, claim.Name)

--- a/internal/poolutil/pool.go
+++ b/internal/poolutil/pool.go
@@ -209,7 +209,7 @@ func IPSetCount(ipSet *netipx.IPSet) int {
 	// If total is greater than Uint64, Uint64() will return 0
 	// We want to display MaxInt if the value overflows what int can contain
 	if total.IsInt64() && total.Uint64() <= uint64(math.MaxInt) {
-		return int(total.Uint64())
+		return int(total.Uint64()) //nolint:gosec // [G115] conversion is safe with check beforehand
 	}
 	return math.MaxInt
 }


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Upgrades golangci-lint to 1.60.2
Configuration is mostly copied from CAPI, removing the unnecessary parts
A few changes to make the linter happy

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
