### PR TITLE
Allow IPPool to have Prefix /0

### DIFF
--- a/api/v1alpha2/inclusterippool_types.go
+++ b/api/v1alpha2/inclusterippool_types.go
@@ -28,6 +28,7 @@ type InClusterIPPoolSpec struct {
 
 	// Prefix is the network prefix to use.
 	// +kubebuilder:validation:Maximum=128
+	// +kubebuilder:validation:Minimum=0
 	Prefix int `json:"prefix"`
 
 	// Gateway

--- a/config/crd/bases/ipam.cluster.x-k8s.io_globalinclusterippools.yaml
+++ b/config/crd/bases/ipam.cluster.x-k8s.io_globalinclusterippools.yaml
@@ -217,6 +217,7 @@ spec:
               prefix:
                 description: Prefix is the network prefix to use.
                 maximum: 128
+                minimum: 0
                 type: integer
             required:
             - addresses

--- a/config/crd/bases/ipam.cluster.x-k8s.io_inclusterippools.yaml
+++ b/config/crd/bases/ipam.cluster.x-k8s.io_inclusterippools.yaml
@@ -215,6 +215,7 @@ spec:
               prefix:
                 description: Prefix is the network prefix to use.
                 maximum: 128
+                minimum: 0
                 type: integer
             required:
             - addresses

--- a/internal/poolutil/pool_test.go
+++ b/internal/poolutil/pool_test.go
@@ -28,6 +28,23 @@ import (
 )
 
 var _ = Describe("PoolSpecToIPSet", func() {
+	It("should allow a pool spec with prefix /0", func() {
+		spec := &v1alpha2.InClusterIPPoolSpec{
+			Gateway: "192.168.0.1",
+			Prefix:  0,
+			Addresses: []string{
+				"192.168.0.3-192.168.0.10",
+			},
+		}
+		ipSet, err := PoolSpecToIPSet(spec)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ipSet.Contains(mustParse("192.168.0.3"))).To(BeTrue())
+		Expect(ipSet.Contains(mustParse("192.168.0.3"))).To(BeTrue())
+		Expect(ipSet.Contains(mustParse("192.168.0.5"))).To(BeTrue())
+		Expect(ipSet.Contains(mustParse("192.168.0.6"))).To(BeTrue())
+		Expect(ipSet.Contains(mustParse("192.168.0.7"))).To(BeTrue())
+		Expect(IPSetCount(ipSet)).To(Equal(8))
+	})
 	It("converts a pool spec to a set", func() {
 		spec := &v1alpha2.InClusterIPPoolSpec{
 			Gateway: "192.168.0.1",

--- a/internal/webhooks/inclusterippool.go
+++ b/internal/webhooks/inclusterippool.go
@@ -185,6 +185,10 @@ func (webhook *InClusterIPPool) validate(_, newPool types.GenericInClusterPool) 
 		allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "addresses"), newPool.PoolSpec().Addresses, "addresses is required"))
 	}
 
+	if newPool.PoolSpec().Prefix < 0 {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "prefix"), newPool.PoolSpec().Addresses, "a valid prefix is required"))
+	}
+
 	var hasIPv4Addr, hasIPv6Addr bool
 	for _, address := range newPool.PoolSpec().Addresses {
 		ipSet, err := poolutil.AddressToIPSet(address)

--- a/internal/webhooks/inclusterippool.go
+++ b/internal/webhooks/inclusterippool.go
@@ -185,10 +185,6 @@ func (webhook *InClusterIPPool) validate(_, newPool types.GenericInClusterPool) 
 		allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "addresses"), newPool.PoolSpec().Addresses, "addresses is required"))
 	}
 
-	if newPool.PoolSpec().Prefix == 0 {
-		allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "prefix"), newPool.PoolSpec().Prefix, "a valid prefix is required"))
-	}
-
 	var hasIPv4Addr, hasIPv6Addr bool
 	for _, address := range newPool.PoolSpec().Addresses {
 		ipSet, err := poolutil.AddressToIPSet(address)

--- a/internal/webhooks/inclusterippool_test.go
+++ b/internal/webhooks/inclusterippool_test.go
@@ -419,6 +419,18 @@ func TestInvalidScenarios(t *testing.T) {
 			expectedError: "provided address is not a valid IP, range, nor CIDR",
 		},
 		{
+			testcase: "negative prefix not allowed",
+			spec: v1alpha2.InClusterIPPoolSpec{
+				Addresses: []string{
+					"10.0.0.25",
+					"10.0.0.26",
+				},
+				Prefix:  -1,
+				Gateway: "10.0.0.1",
+			},
+			expectedError: "a valid prefix is required",
+		},
+		{
 			testcase: "specifying an invalid prefix",
 			spec: v1alpha2.InClusterIPPoolSpec{
 				Addresses: []string{


### PR DESCRIPTION
This PR allows the IPPoolSpec to have /0 prefix.
I added tests for webhook and pool spec.

Closes #287 
