### PR TITLE
:bug: fix skipping reconciliation, when a referenced cluster is already deleted

### DIFF
--- a/pkg/ipamutil/reconciler.go
+++ b/pkg/ipamutil/reconciler.go
@@ -140,11 +140,12 @@ func (r *ClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ct
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			if !claim.ObjectMeta.DeletionTimestamp.IsZero() {
+				patch := client.MergeFrom(claim.DeepCopy())
 				if err := r.reconcileDelete(ctx, claim); err != nil {
 					return ctrl.Result{}, fmt.Errorf("reconcile delete: %w", err)
 				}
-				// we'll need to explicitly update the claim here since we haven't set up a patch helper yet.
-				if err := r.Client.Update(ctx, claim); err != nil {
+				// we'll need to explicitly patch the claim here since we haven't set up a patch helper yet.
+				if err := r.Client.Patch(ctx, claim, patch); err != nil {
 					return ctrl.Result{}, fmt.Errorf("patch after reconciling delete: %w", err)
 				}
 				return ctrl.Result{}, nil
@@ -272,8 +273,9 @@ func (r *ClaimReconciler) reconcileDelete(ctx context.Context, claim *ipamv1.IPA
 
 	if address.Name != "" {
 		var err error
+		patch := client.MergeFrom(address.DeepCopy())
 		if controllerutil.RemoveFinalizer(address, ProtectAddressFinalizer) {
-			if err = r.Client.Update(ctx, address); err != nil && !apierrors.IsNotFound(err) {
+			if err = r.Client.Patch(ctx, address, patch); err != nil && !apierrors.IsNotFound(err) {
 				return errors.Wrap(err, "failed to remove address finalizer")
 			}
 		}


### PR DESCRIPTION
Currently there is a bug, that if you delete a cluster, which is referenced in an IPAddressClaim, the IPAddressClaim won't be deleted and in the log, the following message is shown instead:
`IPAddressClaim linked to a cluster that is not found, unable to determine cluster's paused state, skipping reconciliation`
This is due to the function `r.reconcileDelete()` only deleting the ReleaseAddressFinalizer in the local copy of the claim and not in the actual object. The update of the object is missing.

This PR fixes this behaviour by adding the update clause to update the object in k8s/etcd.