### PR TITLE
🌱 Bump cloudbuild, and use go-version-file for setup-go action

### DIFF
--- a/.github/workflows/draft_release.yaml
+++ b/.github/workflows/draft_release.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.23'
+          go-version-file: go.mod
       # - name: generate release notes
       #   run: |
       #     make release-notes

--- a/.github/workflows/pullrequests.yaml
+++ b/.github/workflows/pullrequests.yaml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version-file: go.mod
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8.0.0
         with:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,7 +4,7 @@ timeout: 1800s
 options:
   substitution_option: ALLOW_LOOSE
 steps:
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20250116-2a05ea7e3d'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20250513-9264efb079'
     entrypoint: make
     env:
       - DOCKER_CLI_EXPERIMENTAL=enabled


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Bump Cloud build to `v20250513-9264efb079`.
Use go-version-file: go.mod for setup-go action

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
