### PR TITLE
:seedling:  remove rikatz from reviewers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -9,5 +9,4 @@ aliases:
   cluster-api-ipam-provider-in-cluster-reviewers:
     - schrej
     - srm09
-    - rikatz
     - mcbenjemaa


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: Remove rikatz from reviewers

I am mostly focused on all networking things, (Gateway API) and am not being really able to deal with PRs here, so stepping down

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
