### PR TITLE
🌱 fix: Pin Actions to a full commit SHA & Bump Go to v1.26

### DIFF
--- a/.github/workflows/draft_release.yaml
+++ b/.github/workflows/draft_release.yaml
@@ -16,11 +16,11 @@ jobs:
       # - name: Set env
       #   run:  echo "RELEASE_TAG=${GITHUB_REF:10}" >> $GITHUB_ENV
       - name: Checkout the Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: go.mod
       # - name: generate release notes
@@ -30,7 +30,7 @@ jobs:
         run: |
           make release
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           draft: true
           files: out/*.*

--- a/.github/workflows/pullrequests.yaml
+++ b/.github/workflows/pullrequests.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
-          version: v2.1.6
+          version: v2.11.4
           args: '--timeout 10m'
 
   test:

--- a/.github/workflows/pullrequests.yaml
+++ b/.github/workflows/pullrequests.yaml
@@ -11,12 +11,12 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: go.mod
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9.2.0
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
           version: v2.1.6
           args: '--timeout 10m'
@@ -25,10 +25,10 @@ jobs:
     name: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: "1.23"
+          go-version-file: go.mod
       - name: Run Tests
         run: make test
 
@@ -36,10 +36,10 @@ jobs:
     name: validate generated files
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: "1.23"
+          go-version-file: go.mod
       - name: run code generators
         run: make generate
       - name: run manifest generators

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 version: "2"
 run:
-  go: "1.23"
+  go: "1.26"
   build-tags:
     - e2e
   allow-parallel-runners: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@
 ARG ARCH
 
 # Build the manager binary
-FROM golang:1.24 AS builder
+FROM golang:1.26 AS builder
 
 # builder ARGs. No inheritance from global ARGs, so we need to redeclare them.
 ARG ARCH

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ ARCH ?= $(shell go env GOARCH)
 ALL_ARCH ?= amd64 arm64
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.29
+ENVTEST_K8S_VERSION = 1.33
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -243,4 +243,4 @@ verify-boilerplate: ## Verifies all sources have appropriate boilerplate
 CONVERSION_GEN = $(HACK_BIN)/conversion-gen
 .PHONY: conversion-gen
 conversion-gen: ## Download conversion-gen locally if necessary.
-	env GOBIN=$(HACK_BIN) go install k8s.io/code-generator/cmd/conversion-gen@v0.30.1
+	env GOBIN=$(HACK_BIN) go install k8s.io/code-generator/cmd/conversion-gen@v0.33.11

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/cluster-api-ipam-provider-in-cluster
 
-go 1.24.3
+go 1.26.2
 
 require (
 	github.com/onsi/ginkgo/v2 v2.27.2


### PR DESCRIPTION
We are enforced to use commit SHA

```
Error: The actions actions/checkout@v6, actions/setup-go@v5, and golangci/golangci-lint-action@v9.2.0 are not allowed in kubernetes-sigs/cluster-api-ipam-provider-in-cluster because all actions must be pinned to a full-length commit SHA.
```

https://github.com/kubernetes-sigs/cluster-api-ipam-provider-in-cluster/actions/runs/24990113492/job/73173329503?pr=387

