### PR TITLE
feat: add --leader-election-namespace flag to manager

### DIFF
--- a/main.go
+++ b/main.go
@@ -62,10 +62,11 @@ func init() {
 
 func main() {
 	var (
-		enableLeaderElection bool
-		probeAddr            string
-		watchNamespace       string
-		watchFilter          string
+		enableLeaderElection    bool
+		leaderElectionNamespace string
+		probeAddr               string
+		watchNamespace          string
+		watchFilter             string
 
 		managerOptions = flags.ManagerOptions{}
 
@@ -82,6 +83,8 @@ func main() {
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
+	flag.StringVar(&leaderElectionNamespace, "leader-election-namespace", "",
+		"Namespace used to store the leader election lock. If unspecified, the controller manager will use the namespace of the pod running the controller manager.")
 	flag.StringVar(&watchNamespace, "namespace", "",
 		"Namespace that the controller watches to reconcile cluster-api objects. If unspecified, the controller watches for cluster-api objects across all namespaces.")
 	flag.StringVar(&watchFilter, "watch-filter", "", "")
@@ -109,8 +112,9 @@ func main() {
 		Metrics:                *metricsOpts,
 		Scheme:                 scheme,
 		HealthProbeBindAddress: probeAddr,
-		LeaderElection:         enableLeaderElection,
-		LeaderElectionID:       "7bb7acb4.ipam.cluster.x-k8s.io",
+		LeaderElection:          enableLeaderElection,
+		LeaderElectionID:        "7bb7acb4.ipam.cluster.x-k8s.io",
+		LeaderElectionNamespace: leaderElectionNamespace,
 		WebhookServer: webhook.NewServer(
 			webhook.Options{
 				Port:     webhookPort,

--- a/main.go
+++ b/main.go
@@ -109,9 +109,9 @@ func main() {
 	ctx := ctrl.SetupSignalHandler()
 
 	opts := ctrl.Options{
-		Metrics:                *metricsOpts,
-		Scheme:                 scheme,
-		HealthProbeBindAddress: probeAddr,
+		Metrics:                 *metricsOpts,
+		Scheme:                  scheme,
+		HealthProbeBindAddress:  probeAddr,
 		LeaderElection:          enableLeaderElection,
 		LeaderElectionID:        "7bb7acb4.ipam.cluster.x-k8s.io",
 		LeaderElectionNamespace: leaderElectionNamespace,


### PR DESCRIPTION
## Summary

- Adds a new `--leader-election-namespace` CLI flag to the controller manager.
- The flag maps directly to `ctrl.Options.LeaderElectionNamespace`, which is passed to controller-runtime.
- When unset, controller-runtime continues to default to the pod's own namespace — no behaviour change for existing deployments.

## Motivation

Some deployment scenarios require the leader election lock to live in a specific namespace that differs from the pod's namespace (e.g. multi-tenant setups, cross-namespace deployments, or environments where the pod namespace annotation is unavailable). This flag brings the manager in line with other CAPI providers that already expose this knob.

## Test plan

- [ ] Existing unit and e2e test suite passes — no logic was changed, only a new flag is wired through.
- [ ] Manual verification: start the manager with `--leader-elect=true --leader-election-namespace=<ns>` and confirm the `lease` object is created in the specified namespace.